### PR TITLE
Fix build on FreeBSD -CURRENT.

### DIFF
--- a/trunk/kernel/ietbsd.h
+++ b/trunk/kernel/ietbsd.h
@@ -11,6 +11,7 @@
 #include <sys/malloc.h>
 #include <sys/lock.h>
 #include <sys/mutex.h>
+#include <sys/rwlock.h>
 #include <sys/bio.h>
 #include <sys/time.h>
 #include <sys/queue.h>

--- a/trunk/usr/bsddefs.h
+++ b/trunk/usr/bsddefs.h
@@ -1,6 +1,8 @@
 #ifndef BSDDEFS_H_
 #define BSDDEFS_H_  1
 
+#include <sys/param.h>
+
 #define SOL_TCP		IPPROTO_TCP
 #define TCP_CORK	TCP_NOPUSH
 
@@ -8,6 +10,7 @@
 #define s6_addr16 __u6_addr.__u6_addr16
 #define s6_addr32 __u6_addr.__u6_addr32
 
+#if __FreeBSD_version < 1000028
 static inline char *
 strchrnul (const char *s, int c_in)
 {
@@ -17,5 +20,6 @@ strchrnul (const char *s, int c_in)
 
 	return (char *) s;
 }
+#endif
 
 #endif


### PR DESCRIPTION
- Include rwlock.h  This is needed by new VM code.
  - strchrnul() is available on FreeBSD >= 1000028, don't define if
    that's the case.
